### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -355,8 +355,8 @@ export default {
       },
       "mvpd": {
         "latest": {
-          "version": "05.70.40",
-          "release": "3.4.3-590810",
+          "version": "05.70.45",
+          "release": "3.4.3-590811",
           "codename": "dreadlocks-digya"
         }
       }
@@ -422,8 +422,8 @@ export default {
       },
       "mvpd": {
         "latest": {
-          "version": "05.70.45",
-          "release": "3.4.3-580511",
+          "version": "05.70.50",
+          "release": "3.4.3-580512",
           "codename": "dreadlocks-digya"
         }
       }
@@ -446,8 +446,8 @@ export default {
       },
       "mvpd": {
         "latest": {
-          "version": "05.70.45",
-          "release": "3.4.3-580511",
+          "version": "05.70.50",
+          "release": "3.4.3-580512",
           "codename": "dreadlocks-digya"
         }
       }
@@ -642,8 +642,8 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "06.10.70",
-          "release": "3.9.3-62916",
+          "version": "06.10.75",
+          "release": "3.9.3-62917",
           "codename": "dreadlocks2-dudhwa"
         }
       }
@@ -690,8 +690,8 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "06.10.50",
-          "release": "3.9.3-63013",
+          "version": "06.10.55",
+          "release": "3.9.3-63014",
           "codename": "dreadlocks2-dudhwa"
         }
       }
@@ -3852,6 +3852,11 @@ export default {
         "latest": {
           "version": "04.50.86",
           "release": "7.5.0-1705",
+          "codename": "mullet-mirima"
+        },
+        "patched": {
+          "version": "04.53.40",
+          "release": "7.5.1-9",
           "codename": "mullet-mirima"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- latest mvpd rootable firmware of HE_DTV_W16N_AFADABAA has been updated to 05.70.45
- latest mvpd rootable firmware of HE_DTV_W16P_AFADABAA has been updated to 05.70.50
- latest mvpd rootable firmware of HE_DTV_W16P_AFADATAA has been updated to 05.70.50
- latest dejavuln rootable firmware of HE_DTV_W17P_AFADABAA has been updated to 06.10.75
- latest dejavuln rootable firmware of HE_DTV_W17R_AFAAABAA has been updated to 06.10.55
- faultmanager on HE_DTV_W22A_AFADATAA has been patched in 04.53.40 (webOS 7.5.1-9, mullet)