### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -3784,8 +3784,8 @@ export default {
       },
       "faultmanager": {
         "latest": {
-          "version": "04.42.26",
-          "release": "7.4.0-3015",
+          "version": "04.42.27",
+          "release": "7.4.0-3016",
           "codename": "mullet-meru"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- latest faultmanager rootable firmware of HE_DTV_C22P_AFADATAA has been updated to 04.42.27