### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -2317,8 +2317,8 @@ export default {
       },
       "faultmanager": {
         "latest": {
-          "version": "04.60.46",
-          "release": "5.6.0-1001",
+          "version": "04.60.47",
+          "release": "5.6.0-1002",
           "codename": "jhericurl-jimna"
         }
       }
@@ -2601,8 +2601,8 @@ export default {
       },
       "faultmanager": {
         "latest": {
-          "version": "04.60.46",
-          "release": "5.6.0-1001",
+          "version": "04.60.47",
+          "release": "5.6.0-1002",
           "codename": "jhericurl-jimna"
         }
       }
@@ -3027,8 +3027,8 @@ export default {
       },
       "faultmanager": {
         "latest": {
-          "version": "04.60.46",
-          "release": "5.6.0-1001",
+          "version": "04.60.47",
+          "release": "5.6.0-1002",
           "codename": "jhericurl-jimna"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- latest faultmanager rootable firmware of HE_DTV_W20H_AFADJAAA has been updated to 04.60.47
- latest faultmanager rootable firmware of HE_DTV_W20L_AFAAJAAA has been updated to 04.60.47
- latest faultmanager rootable firmware of HE_DTV_W20P_AFADJAAA has been updated to 04.60.47