### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -4475,6 +4475,11 @@ export default {
           "version": "23.21.28",
           "release": "9.2.1-4004",
           "codename": "ombre-okapi"
+        },
+        "patched": {
+          "version": "23.22.02",
+          "release": "9.2.1-4009",
+          "codename": "ombre-okapi"
         }
       }
     }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- faultmanager on HE_DTV_W23H_AFADATAA has been patched in 23.22.02 (webOS 9.2.1-4009, ombre)