### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -2246,8 +2246,8 @@ export default {
       },
       "faultmanager": {
         "latest": {
-          "version": "04.60.46",
-          "release": "5.6.0-1001",
+          "version": "04.60.47",
+          "release": "5.6.0-1002",
           "codename": "jhericurl-jimna"
         }
       }
@@ -2885,8 +2885,8 @@ export default {
       },
       "faultmanager": {
         "latest": {
-          "version": "04.60.46",
-          "release": "5.6.0-1001",
+          "version": "04.60.47",
+          "release": "5.6.0-1002",
           "codename": "jhericurl-jimna"
         }
       }
@@ -2956,8 +2956,8 @@ export default {
       },
       "faultmanager": {
         "latest": {
-          "version": "04.60.46",
-          "release": "5.6.0-1001",
+          "version": "04.60.47",
+          "release": "5.6.0-1002",
           "codename": "jhericurl-jimna"
         }
       }
@@ -3309,6 +3309,11 @@ export default {
         "latest": {
           "version": "03.51.16",
           "release": "6.5.0-2401",
+          "codename": "kisscurl-koli"
+        },
+        "patched": {
+          "version": "03.52.55",
+          "release": "6.5.1-36",
           "codename": "kisscurl-koli"
         }
       }
@@ -4527,6 +4532,11 @@ export default {
         "latest": {
           "version": "23.21.28",
           "release": "9.2.1-4004",
+          "codename": "ombre-okapi"
+        },
+        "patched": {
+          "version": "23.22.02",
+          "release": "9.2.1-4009",
           "codename": "ombre-okapi"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- latest faultmanager rootable firmware of HE_DTV_W20H_AFADABAA has been updated to 04.60.47
- latest faultmanager rootable firmware of HE_DTV_W20P_AFADABAA has been updated to 04.60.47
- latest faultmanager rootable firmware of HE_DTV_W20P_AFADATAA has been updated to 04.60.47
- faultmanager on HE_DTV_W21K_AFADATAA has been patched in 03.52.55 (webOS 6.5.1-36, kisscurl)
- faultmanager on HE_DTV_W23H_AFADJAAA has been patched in 23.22.02 (webOS 9.2.1-4009, ombre)