### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -1997,15 +1997,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.85",
+          "release": "4.10.1-25",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.85",
+          "release": "4.10.1-25",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -3380,6 +3380,11 @@ export default {
         "latest": {
           "version": "03.51.16",
           "release": "6.5.0-2401",
+          "codename": "kisscurl-koli"
+        },
+        "patched": {
+          "version": "03.52.55",
+          "release": "6.5.1-36",
           "codename": "kisscurl-koli"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- latest dejavuln rootable firmware of HE_DTV_W19R_AFAAATAA has been updated to 05.40.85
- latest faultmanager rootable firmware of HE_DTV_W19R_AFAAATAA has been updated to 05.40.85
- faultmanager on HE_DTV_W21K_AFADJAAA has been patched in 03.52.55 (webOS 6.5.1-36, kisscurl)