### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -832,29 +832,29 @@ export default {
       },
       "crashd": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.65",
+          "release": "4.4.3-21",
           "codename": "goldilocks-gorongosa"
         }
       },
       "asm": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.65",
+          "release": "4.4.3-21",
           "codename": "goldilocks-gorongosa"
         }
       },
       "dejavuln": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.65",
+          "release": "4.4.3-21",
           "codename": "goldilocks-gorongosa"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.65",
+          "release": "4.4.3-21",
           "codename": "goldilocks-gorongosa"
         }
       }
@@ -876,29 +876,29 @@ export default {
       },
       "crashd": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.65",
+          "release": "4.4.3-21",
           "codename": "goldilocks-gorongosa"
         }
       },
       "asm": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.65",
+          "release": "4.4.3-21",
           "codename": "goldilocks-gorongosa"
         }
       },
       "dejavuln": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.65",
+          "release": "4.4.3-21",
           "codename": "goldilocks-gorongosa"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.65",
+          "release": "4.4.3-21",
           "codename": "goldilocks-gorongosa"
         }
       }
@@ -1179,29 +1179,29 @@ export default {
       },
       "crashd": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.65",
+          "release": "4.4.3-21",
           "codename": "goldilocks-gorongosa"
         }
       },
       "asm": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.65",
+          "release": "4.4.3-21",
           "codename": "goldilocks-gorongosa"
         }
       },
       "dejavuln": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.65",
+          "release": "4.4.3-21",
           "codename": "goldilocks-gorongosa"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.65",
+          "release": "4.4.3-21",
           "codename": "goldilocks-gorongosa"
         }
       }
@@ -1943,15 +1943,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.85",
+          "release": "4.10.1-25",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.85",
+          "release": "4.10.1-25",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -3241,8 +3241,8 @@ export default {
       },
       "faultmanager": {
         "latest": {
-          "version": "03.51.16",
-          "release": "6.5.0-2401",
+          "version": "03.51.17",
+          "release": "6.5.0-2402",
           "codename": "kisscurl-koli"
         }
       }
@@ -3457,6 +3457,11 @@ export default {
           "version": "03.51.16",
           "release": "6.5.0-2401",
           "codename": "kisscurl-koli"
+        },
+        "patched": {
+          "version": "03.52.50",
+          "release": "6.5.1-35",
+          "codename": "kisscurl-koli"
         }
       }
     }
@@ -3528,6 +3533,11 @@ export default {
           "version": "03.51.16",
           "release": "6.5.0-2401",
           "codename": "kisscurl-koli"
+        },
+        "patched": {
+          "version": "03.52.55",
+          "release": "6.5.1-36",
+          "codename": "kisscurl-koli"
         }
       }
     }
@@ -3596,8 +3606,8 @@ export default {
       },
       "faultmanager": {
         "latest": {
-          "version": "03.51.16",
-          "release": "6.5.0-2401",
+          "version": "03.51.17",
+          "release": "6.5.0-2402",
           "codename": "kisscurl-koli"
         }
       }
@@ -4972,8 +4982,8 @@ export default {
     "ombre": {
       "faultmanager": {
         "latest": {
-          "version": "23.21.01",
-          "release": "9.2.2-2404",
+          "version": "23.21.02",
+          "release": "9.2.2-2405",
           "codename": "ombre-okapi"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- latest crashd rootable firmware of HE_DTV_W18A_AFADABAA has been updated to 05.50.65
- latest asm rootable firmware of HE_DTV_W18A_AFADABAA has been updated to 05.50.65
- latest dejavuln rootable firmware of HE_DTV_W18A_AFADABAA has been updated to 05.50.65
- latest faultmanager rootable firmware of HE_DTV_W18A_AFADABAA has been updated to 05.50.65
- latest crashd rootable firmware of HE_DTV_W18A_AFADATAA has been updated to 05.50.65
- latest asm rootable firmware of HE_DTV_W18A_AFADATAA has been updated to 05.50.65
- latest dejavuln rootable firmware of HE_DTV_W18A_AFADATAA has been updated to 05.50.65
- latest faultmanager rootable firmware of HE_DTV_W18A_AFADATAA has been updated to 05.50.65
- latest crashd rootable firmware of HE_DTV_W18R_AFAAABAA has been updated to 05.50.65
- latest asm rootable firmware of HE_DTV_W18R_AFAAABAA has been updated to 05.50.65
- latest dejavuln rootable firmware of HE_DTV_W18R_AFAAABAA has been updated to 05.50.65
- latest faultmanager rootable firmware of HE_DTV_W18R_AFAAABAA has been updated to 05.50.65
- latest dejavuln rootable firmware of HE_DTV_W19R_AFAAABAA has been updated to 05.40.85
- latest faultmanager rootable firmware of HE_DTV_W19R_AFAAABAA has been updated to 05.40.85
- latest faultmanager rootable firmware of HE_DTV_W21A_AFADATAA has been updated to 03.51.17
- faultmanager on HE_DTV_W21O_AFABATAA has been patched in 03.52.50 (webOS 6.5.1-35, kisscurl)
- faultmanager on HE_DTV_W21P_AFADATAA has been patched in 03.52.55 (webOS 6.5.1-36, kisscurl)
- latest faultmanager rootable firmware of HE_DTV_W21U_AFADATAA has been updated to 03.51.17
- latest faultmanager rootable firmware of HE_DTV_W24P_AFADATAA has been updated to 23.21.02