### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -1457,15 +1457,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- latest dejavuln rootable firmware of HE_DTV_W19H_AFADATAA has been updated to 05.40.90
- latest faultmanager rootable firmware of HE_DTV_W19H_AFADATAA has been updated to 05.40.90