### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -1511,15 +1511,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1727,15 +1727,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- updated: dejavuln on HE_DTV_W19H_AFADJAAA is known rootable in 05.40.90
- updated: faultmanager on HE_DTV_W19H_AFADJAAA is known rootable in 05.40.90
- updated: dejavuln on HE_DTV_W19O_AFABATAA is known rootable in 05.40.90
- updated: faultmanager on HE_DTV_W19O_AFABATAA is known rootable in 05.40.90