### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -1565,15 +1565,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1619,15 +1619,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -4126,6 +4126,11 @@ export default {
         "latest": {
           "version": "04.51.05",
           "release": "7.5.0-22",
+          "codename": "mullet-mirima"
+        },
+        "patched": {
+          "version": "04.53.42",
+          "release": "7.5.1-902",
           "codename": "mullet-mirima"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- updated: dejavuln on HE_DTV_W19K_AFADABAA is known rootable in 05.40.90
- updated: faultmanager on HE_DTV_W19K_AFADABAA is known rootable in 05.40.90
- updated: dejavuln on HE_DTV_W19K_AFADJAAA is known rootable in 05.40.90
- updated: faultmanager on HE_DTV_W19K_AFADJAAA is known rootable in 05.40.90
- patched: faultmanager on HE_DTV_W22L_AFAAATAA in 04.53.42 (webOS 7.5.1-902, mullet)