### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -920,29 +920,29 @@ export default {
       },
       "crashd": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "asm": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "dejavuln": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       }
@@ -964,29 +964,29 @@ export default {
       },
       "crashd": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "asm": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "dejavuln": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       }
@@ -1008,29 +1008,29 @@ export default {
       },
       "crashd": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "asm": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "dejavuln": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       }
@@ -1052,29 +1052,29 @@ export default {
       },
       "crashd": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "asm": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "dejavuln": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       }
@@ -1135,29 +1135,29 @@ export default {
       },
       "crashd": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "asm": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "dejavuln": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.50.60",
-          "release": "4.4.3-20",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       }
@@ -1403,15 +1403,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1673,15 +1673,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -3244,6 +3244,11 @@ export default {
           "version": "03.51.17",
           "release": "6.5.0-2402",
           "codename": "kisscurl-koli"
+        },
+        "patched": {
+          "version": "03.52.60",
+          "release": "6.5.1-37",
+          "codename": "kisscurl-koli"
         }
       }
     }
@@ -3608,6 +3613,11 @@ export default {
         "latest": {
           "version": "03.51.17",
           "release": "6.5.0-2402",
+          "codename": "kisscurl-koli"
+        },
+        "patched": {
+          "version": "03.52.60",
+          "release": "6.5.1-37",
           "codename": "kisscurl-koli"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- updated: crashd on HE_DTV_W18H_AFADABAA is known rootable in 05.50.70
- updated: asm on HE_DTV_W18H_AFADABAA is known rootable in 05.50.70
- updated: dejavuln on HE_DTV_W18H_AFADABAA is known rootable in 05.50.70
- updated: faultmanager on HE_DTV_W18H_AFADABAA is known rootable in 05.50.70
- updated: crashd on HE_DTV_W18H_AFADJAAA is known rootable in 05.50.70
- updated: asm on HE_DTV_W18H_AFADJAAA is known rootable in 05.50.70
- updated: dejavuln on HE_DTV_W18H_AFADJAAA is known rootable in 05.50.70
- updated: faultmanager on HE_DTV_W18H_AFADJAAA is known rootable in 05.50.70
- updated: crashd on HE_DTV_W18M_AFADJAAA is known rootable in 05.50.70
- updated: asm on HE_DTV_W18M_AFADJAAA is known rootable in 05.50.70
- updated: dejavuln on HE_DTV_W18M_AFADJAAA is known rootable in 05.50.70
- updated: faultmanager on HE_DTV_W18M_AFADJAAA is known rootable in 05.50.70
- updated: crashd on HE_DTV_W18O_AFABABAA is known rootable in 05.50.70
- updated: asm on HE_DTV_W18O_AFABABAA is known rootable in 05.50.70
- updated: dejavuln on HE_DTV_W18O_AFABABAA is known rootable in 05.50.70
- updated: faultmanager on HE_DTV_W18O_AFABABAA is known rootable in 05.50.70
- updated: crashd on HE_DTV_W18O_AFABJAAA is known rootable in 05.50.70
- updated: asm on HE_DTV_W18O_AFABJAAA is known rootable in 05.50.70
- updated: dejavuln on HE_DTV_W18O_AFABJAAA is known rootable in 05.50.70
- updated: faultmanager on HE_DTV_W18O_AFABJAAA is known rootable in 05.50.70
- updated: dejavuln on HE_DTV_W19H_AFADABAA is known rootable in 05.40.90
- updated: faultmanager on HE_DTV_W19H_AFADABAA is known rootable in 05.40.90
- updated: dejavuln on HE_DTV_W19O_AFABABAA is known rootable in 05.40.90
- updated: faultmanager on HE_DTV_W19O_AFABABAA is known rootable in 05.40.90
- patched: faultmanager on HE_DTV_W21A_AFADATAA in 03.52.60 (webOS 6.5.1-37, kisscurl)
- patched: faultmanager on HE_DTV_W21U_AFADATAA in 03.52.60 (webOS 6.5.1-37, kisscurl)