### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -3817,6 +3817,11 @@ export default {
           "version": "04.42.27",
           "release": "7.4.0-3016",
           "codename": "mullet-meru"
+        },
+        "patched": {
+          "version": "04.51.57",
+          "release": "7.5.0-3202",
+          "codename": "mullet-mirima"
         }
       }
     }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- patched: faultmanager on HE_DTV_C22P_AFADATAA in 04.51.57 (webOS 7.5.0-3202, mullet)