### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -594,8 +594,8 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "06.10.60",
-          "release": "3.9.3-6270914",
+          "version": "06.10.65",
+          "release": "3.9.3-6270915",
           "codename": "dreadlocks2-dudhwa"
         }
       }
@@ -1781,15 +1781,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.90",
+          "release": "4.10.1-26",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -4371,8 +4371,8 @@ export default {
       },
       "faultmanager": {
         "latest": {
-          "version": "03.30.36",
-          "release": "8.3.0-37",
+          "version": "03.30.42",
+          "release": "8.3.0-43",
           "codename": "number1-nameri"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- updated: dejavuln on HE_DTV_W17H_AFADJAAA is known rootable in 06.10.65
- updated: dejavuln on HE_DTV_W19O_AFABJAAA is known rootable in 05.40.90
- updated: faultmanager on HE_DTV_W19O_AFABJAAA is known rootable in 05.40.90
- updated: faultmanager on HE_MNT_S23Y_AAAAGLAA is known rootable in 03.30.42