### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -551,8 +551,8 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "06.10.60",
-          "release": "3.9.3-6270914",
+          "version": "06.10.65",
+          "release": "3.9.3-6270915",
           "codename": "dreadlocks2-dudhwa"
         }
       }
@@ -690,8 +690,8 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "06.10.55",
-          "release": "3.9.3-63014",
+          "version": "06.10.60",
+          "release": "3.9.3-63015",
           "codename": "dreadlocks2-dudhwa"
         }
       }
@@ -714,8 +714,8 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "06.10.55",
-          "release": "3.9.3-63014",
+          "version": "06.10.60",
+          "release": "3.9.3-63015",
           "codename": "dreadlocks2-dudhwa"
         }
       }
@@ -876,29 +876,29 @@ export default {
       },
       "crashd": {
         "latest": {
-          "version": "05.50.65",
-          "release": "4.4.3-21",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "asm": {
         "latest": {
-          "version": "05.50.65",
-          "release": "4.4.3-21",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "dejavuln": {
         "latest": {
-          "version": "05.50.65",
-          "release": "4.4.3-21",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.50.65",
-          "release": "4.4.3-21",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- updated: dejavuln on HE_DTV_W17H_AFADABAA is known rootable in 06.10.65
- updated: dejavuln on HE_DTV_W17R_AFAAABAA is known rootable in 06.10.60
- updated: dejavuln on HE_DTV_W17R_AFAAATAA is known rootable in 06.10.60
- updated: crashd on HE_DTV_W18A_AFADATAA is known rootable in 05.50.70
- updated: asm on HE_DTV_W18A_AFADATAA is known rootable in 05.50.70
- updated: dejavuln on HE_DTV_W18A_AFADATAA is known rootable in 05.50.70
- updated: faultmanager on HE_DTV_W18A_AFADATAA is known rootable in 05.50.70