### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -618,8 +618,8 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "06.10.50",
-          "release": "3.9.3-6280412",
+          "version": "06.10.55",
+          "release": "3.9.3-6280413",
           "codename": "dreadlocks2-dudhwa"
         }
       }
@@ -832,29 +832,29 @@ export default {
       },
       "crashd": {
         "latest": {
-          "version": "05.50.65",
-          "release": "4.4.3-21",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "asm": {
         "latest": {
-          "version": "05.50.65",
-          "release": "4.4.3-21",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "dejavuln": {
         "latest": {
-          "version": "05.50.65",
-          "release": "4.4.3-21",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.50.65",
-          "release": "4.4.3-21",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       }
@@ -1179,29 +1179,29 @@ export default {
       },
       "crashd": {
         "latest": {
-          "version": "05.50.65",
-          "release": "4.4.3-21",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "asm": {
         "latest": {
-          "version": "05.50.65",
-          "release": "4.4.3-21",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "dejavuln": {
         "latest": {
-          "version": "05.50.65",
-          "release": "4.4.3-21",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.50.65",
-          "release": "4.4.3-21",
+          "version": "05.50.70",
+          "release": "4.4.3-22",
           "codename": "goldilocks-gorongosa"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- updated: dejavuln on HE_DTV_W17M_AFADATAA is known rootable in 06.10.55
- updated: crashd on HE_DTV_W18A_AFADABAA is known rootable in 05.50.70
- updated: asm on HE_DTV_W18A_AFADABAA is known rootable in 05.50.70
- updated: dejavuln on HE_DTV_W18A_AFADABAA is known rootable in 05.50.70
- updated: faultmanager on HE_DTV_W18A_AFADABAA is known rootable in 05.50.70
- updated: crashd on HE_DTV_W18R_AFAAABAA is known rootable in 05.50.70
- updated: asm on HE_DTV_W18R_AFAAABAA is known rootable in 05.50.70
- updated: dejavuln on HE_DTV_W18R_AFAAABAA is known rootable in 05.50.70
- updated: faultmanager on HE_DTV_W18R_AFAAABAA is known rootable in 05.50.70