### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -2391,6 +2391,11 @@ export default {
           "version": "04.60.65",
           "release": "5.6.0-14",
           "codename": "jhericurl-jimna"
+        },
+        "patched": {
+          "version": "04.60.67",
+          "release": "5.6.0-1402",
+          "codename": "jhericurl-jimna"
         }
       }
     }
@@ -2462,6 +2467,11 @@ export default {
           "version": "04.60.65",
           "release": "5.6.0-14",
           "codename": "jhericurl-jimna"
+        },
+        "patched": {
+          "version": "04.60.67",
+          "release": "5.6.0-1402",
+          "codename": "jhericurl-jimna"
         }
       }
     }
@@ -2532,6 +2542,11 @@ export default {
         "latest": {
           "version": "04.60.65",
           "release": "5.6.0-14",
+          "codename": "jhericurl-jimna"
+        },
+        "patched": {
+          "version": "04.60.67",
+          "release": "5.6.0-1402",
           "codename": "jhericurl-jimna"
         }
       }
@@ -5004,6 +5019,11 @@ export default {
         "latest": {
           "version": "23.21.02",
           "release": "9.2.2-2405",
+          "codename": "ombre-okapi"
+        },
+        "patched": {
+          "version": "23.22.60",
+          "release": "9.2.3-39",
           "codename": "ombre-okapi"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- patched: faultmanager on HE_DTV_W20K_AFADABAA in 04.60.67 (webOS 5.6.0-1402, jhericurl)
- patched: faultmanager on HE_DTV_W20K_AFADATAA in 04.60.67 (webOS 5.6.0-1402, jhericurl)
- patched: faultmanager on HE_DTV_W20K_AFADJAAA in 04.60.67 (webOS 5.6.0-1402, jhericurl)
- patched: faultmanager on HE_DTV_W24P_AFADATAA in 23.22.60 (webOS 9.2.3-39, ombre)