### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -2249,6 +2249,11 @@ export default {
           "version": "04.60.47",
           "release": "5.6.0-1002",
           "codename": "jhericurl-jimna"
+        },
+        "patched": {
+          "version": "04.60.49",
+          "release": "5.6.0-1004",
+          "codename": "jhericurl-jimna"
         }
       }
     }
@@ -2319,6 +2324,11 @@ export default {
         "latest": {
           "version": "04.60.47",
           "release": "5.6.0-1002",
+          "codename": "jhericurl-jimna"
+        },
+        "patched": {
+          "version": "04.60.49",
+          "release": "5.6.0-1004",
           "codename": "jhericurl-jimna"
         }
       }
@@ -2619,6 +2629,11 @@ export default {
           "version": "04.60.47",
           "release": "5.6.0-1002",
           "codename": "jhericurl-jimna"
+        },
+        "patched": {
+          "version": "04.60.49",
+          "release": "5.6.0-1004",
+          "codename": "jhericurl-jimna"
         }
       }
     }
@@ -2903,6 +2918,11 @@ export default {
           "version": "04.60.47",
           "release": "5.6.0-1002",
           "codename": "jhericurl-jimna"
+        },
+        "patched": {
+          "version": "04.60.49",
+          "release": "5.6.0-1004",
+          "codename": "jhericurl-jimna"
         }
       }
     }
@@ -3044,6 +3064,11 @@ export default {
         "latest": {
           "version": "04.60.47",
           "release": "5.6.0-1002",
+          "codename": "jhericurl-jimna"
+        },
+        "patched": {
+          "version": "04.60.49",
+          "release": "5.6.0-1004",
           "codename": "jhericurl-jimna"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- patched: faultmanager on HE_DTV_W20H_AFADABAA in 04.60.49 (webOS 5.6.0-1004, jhericurl)
- patched: faultmanager on HE_DTV_W20H_AFADJAAA in 04.60.49 (webOS 5.6.0-1004, jhericurl)
- patched: faultmanager on HE_DTV_W20L_AFAAJAAA in 04.60.49 (webOS 5.6.0-1004, jhericurl)
- patched: faultmanager on HE_DTV_W20P_AFADABAA in 04.60.49 (webOS 5.6.0-1004, jhericurl)
- patched: faultmanager on HE_DTV_W20P_AFADJAAA in 04.60.49 (webOS 5.6.0-1004, jhericurl)