### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -2994,6 +2994,11 @@ export default {
           "version": "04.60.47",
           "release": "5.6.0-1002",
           "codename": "jhericurl-jimna"
+        },
+        "patched": {
+          "version": "04.60.49",
+          "release": "5.6.0-1004",
+          "codename": "jhericurl-jimna"
         }
       }
     }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- patched: faultmanager on HE_DTV_W20P_AFADATAA in 04.60.49 (webOS 5.6.0-1004, jhericurl)