### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -1565,15 +1565,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- updated: dejavuln on HE_DTV_W19K_AFADABAA is known rootable in 05.40.97
- updated: faultmanager on HE_DTV_W19K_AFADABAA is known rootable in 05.40.97