### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -1511,15 +1511,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1565,15 +1565,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1619,15 +1619,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1781,15 +1781,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -2846,6 +2846,11 @@ export default {
         "latest": {
           "version": "04.60.65",
           "release": "5.6.0-14",
+          "codename": "jhericurl-jimna"
+        },
+        "patched": {
+          "version": "04.63.15",
+          "release": "5.6.1-4",
           "codename": "jhericurl-jimna"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- updated: dejavuln on HE_DTV_W19H_AFADJAAA is known rootable in 05.40.97
- updated: faultmanager on HE_DTV_W19H_AFADJAAA is known rootable in 05.40.97
- updated: dejavuln on HE_DTV_W19K_AFADABAA is known rootable in 05.40.97
- updated: faultmanager on HE_DTV_W19K_AFADABAA is known rootable in 05.40.97
- updated: dejavuln on HE_DTV_W19K_AFADJAAA is known rootable in 05.40.97
- updated: faultmanager on HE_DTV_W19K_AFADJAAA is known rootable in 05.40.97
- updated: dejavuln on HE_DTV_W19O_AFABJAAA is known rootable in 05.40.97
- updated: faultmanager on HE_DTV_W19O_AFABJAAA is known rootable in 05.40.97
- patched: faultmanager on HE_DTV_W20O_AFABJAAA in 04.63.15 (webOS 5.6.1-4, jhericurl)