### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -1403,15 +1403,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1457,15 +1457,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1673,15 +1673,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1727,15 +1727,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.90",
-          "release": "4.10.1-26",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1835,15 +1835,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1889,15 +1889,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.80",
-          "release": "4.10.1-24",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1943,15 +1943,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.85",
-          "release": "4.10.1-25",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.85",
-          "release": "4.10.1-25",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1997,15 +1997,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.85",
-          "release": "4.10.1-25",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.85",
-          "release": "4.10.1-25",
+          "version": "05.40.97",
+          "release": "4.10.2-29",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -2705,6 +2705,11 @@ export default {
           "version": "04.60.65",
           "release": "5.6.0-14",
           "codename": "jhericurl-jimna"
+        },
+        "patched": {
+          "version": "04.63.15",
+          "release": "5.6.1-4",
+          "codename": "jhericurl-jimna"
         }
       }
     }
@@ -2775,6 +2780,11 @@ export default {
         "latest": {
           "version": "04.60.65",
           "release": "5.6.0-14",
+          "codename": "jhericurl-jimna"
+        },
+        "patched": {
+          "version": "04.63.15",
+          "release": "5.6.1-4",
           "codename": "jhericurl-jimna"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- updated: dejavuln on HE_DTV_W19H_AFADABAA is known rootable in 05.40.97
- updated: faultmanager on HE_DTV_W19H_AFADABAA is known rootable in 05.40.97
- updated: dejavuln on HE_DTV_W19H_AFADATAA is known rootable in 05.40.97
- updated: faultmanager on HE_DTV_W19H_AFADATAA is known rootable in 05.40.97
- updated: dejavuln on HE_DTV_W19O_AFABABAA is known rootable in 05.40.97
- updated: faultmanager on HE_DTV_W19O_AFABABAA is known rootable in 05.40.97
- updated: dejavuln on HE_DTV_W19O_AFABATAA is known rootable in 05.40.97
- updated: faultmanager on HE_DTV_W19O_AFABATAA is known rootable in 05.40.97
- updated: dejavuln on HE_DTV_W19P_AFADABAA is known rootable in 05.40.97
- updated: faultmanager on HE_DTV_W19P_AFADABAA is known rootable in 05.40.97
- updated: dejavuln on HE_DTV_W19P_AFADATAA is known rootable in 05.40.97
- updated: faultmanager on HE_DTV_W19P_AFADATAA is known rootable in 05.40.97
- updated: dejavuln on HE_DTV_W19R_AFAAABAA is known rootable in 05.40.97
- updated: faultmanager on HE_DTV_W19R_AFAAABAA is known rootable in 05.40.97
- updated: dejavuln on HE_DTV_W19R_AFAAATAA is known rootable in 05.40.97
- updated: faultmanager on HE_DTV_W19R_AFAAATAA is known rootable in 05.40.97
- patched: faultmanager on HE_DTV_W20O_AFABABAA in 04.63.15 (webOS 5.6.1-4, jhericurl)
- patched: faultmanager on HE_DTV_W20O_AFABATAA in 04.63.15 (webOS 5.6.1-4, jhericurl)