### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -3745,6 +3745,11 @@ export default {
           "version": "04.41.43",
           "release": "7.4.0-2903",
           "codename": "mullet-meru"
+        },
+        "patched": {
+          "version": "04.55.30",
+          "release": "7.5.3-7",
+          "codename": "mullet-mirima"
         }
       }
     }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- patched: faultmanager on HE_DTV_C22H_AFABATAA in 04.55.30 (webOS 7.5.3-7, mullet)