### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -2105,6 +2105,11 @@ export default {
           "version": "04.50.63",
           "release": "5.5.0-1303",
           "codename": "jhericurl-jervisbay"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
         }
       },
       "faultmanager": {
@@ -2112,6 +2117,11 @@ export default {
           "version": "04.50.63",
           "release": "5.5.0-1303",
           "codename": "jhericurl-jervisbay"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
         }
       }
     }
@@ -2171,6 +2181,11 @@ export default {
           "version": "04.50.63",
           "release": "5.5.0-1303",
           "codename": "jhericurl-jervisbay"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
         }
       },
       "faultmanager": {
@@ -2178,6 +2193,11 @@ export default {
           "version": "04.50.63",
           "release": "5.5.0-1303",
           "codename": "jhericurl-jervisbay"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
         }
       }
     }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- patched: dejavuln on HE_DTV_C20P_AFADABAA in 04.60.95 (webOS 5.6.0-20, jhericurl)
- patched: faultmanager on HE_DTV_C20P_AFADABAA in 04.60.95 (webOS 5.6.0-20, jhericurl)
- patched: dejavuln on HE_DTV_C20P_AFADATAA in 04.60.95 (webOS 5.6.0-20, jhericurl)
- patched: faultmanager on HE_DTV_C20P_AFADATAA in 04.60.95 (webOS 5.6.0-20, jhericurl)