### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -1457,15 +1457,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1511,15 +1511,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1565,15 +1565,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1619,15 +1619,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1727,15 +1727,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1781,15 +1781,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- updated: dejavuln on HE_DTV_W19H_AFADATAA is known rootable in 05.50.00
- updated: faultmanager on HE_DTV_W19H_AFADATAA is known rootable in 05.50.00
- updated: dejavuln on HE_DTV_W19H_AFADJAAA is known rootable in 05.50.00
- updated: faultmanager on HE_DTV_W19H_AFADJAAA is known rootable in 05.50.00
- updated: dejavuln on HE_DTV_W19K_AFADABAA is known rootable in 05.50.00
- updated: faultmanager on HE_DTV_W19K_AFADABAA is known rootable in 05.50.00
- updated: dejavuln on HE_DTV_W19K_AFADJAAA is known rootable in 05.50.00
- updated: faultmanager on HE_DTV_W19K_AFADJAAA is known rootable in 05.50.00
- updated: dejavuln on HE_DTV_W19O_AFABATAA is known rootable in 05.50.00
- updated: faultmanager on HE_DTV_W19O_AFABATAA is known rootable in 05.50.00
- updated: dejavuln on HE_DTV_W19O_AFABJAAA is known rootable in 05.50.00
- updated: faultmanager on HE_DTV_W19O_AFABJAAA is known rootable in 05.50.00