### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -1403,15 +1403,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -1673,15 +1673,15 @@ export default {
       },
       "dejavuln": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       },
       "faultmanager": {
         "latest": {
-          "version": "05.40.97",
-          "release": "4.10.2-29",
+          "version": "05.50.00",
+          "release": "4.10.2-31",
           "codename": "goldilocks2-grampians"
         }
       }
@@ -3836,6 +3836,11 @@ export default {
           "version": "04.41.53",
           "release": "7.4.0-3007",
           "codename": "mullet-meru"
+        },
+        "patched": {
+          "version": "04.55.70",
+          "release": "7.5.6-15",
+          "codename": "mullet-mirima"
         }
       }
     }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- updated: dejavuln on HE_DTV_W19H_AFADABAA is known rootable in 05.50.00
- updated: faultmanager on HE_DTV_W19H_AFADABAA is known rootable in 05.50.00
- updated: dejavuln on HE_DTV_W19O_AFABABAA is known rootable in 05.50.00
- updated: faultmanager on HE_DTV_W19O_AFABABAA is known rootable in 05.50.00
- patched: faultmanager on HE_DTV_C22L_AFAAATAA in 04.55.70 (webOS 7.5.6-15, mullet)