### PR TITLE
Add DangBro exploit (DVB-only)

### DIFF
--- a/src/library.d.ts
+++ b/src/library.d.ts
@@ -20,6 +20,7 @@ export enum DeviceExploitType {
     DejaVuln = 'dejavuln',
     FaultManager = 'faultmanager',
     MVPD = 'mvpd',
+    DangBro = 'dangbro',
 }
 
 export type DeviceExploitAvailabilitiesData = {
@@ -37,6 +38,7 @@ export class DeviceExploitAvailabilities implements DeviceExploitAvailabilitiesD
     readonly dejavuln?: ExploitAvailability;
     readonly faultmanager?: ExploitAvailability;
     readonly mvpd?: ExploitAvailability;
+    readonly dangbro?: ExploitAvailability;
 
     private constructor();
 

--- a/src/library.js
+++ b/src/library.js
@@ -11,6 +11,7 @@ export const DeviceExploitType = {
   DejaVuln: 'dejavuln',
   FaultManager: 'faultmanager',
   MVPD: 'mvpd',
+  DangBro: 'dangbro',
 };
 
 export class DeviceExploitAvailabilities {

--- a/tools/gen-exploits.js
+++ b/tools/gen-exploits.js
@@ -146,6 +146,7 @@ function populateAvailabilities(availabilities, items) {
     hasExploit |= populateExploitAvailability(item, availabilities, "dejavuln", "3.5 - 8");
     hasExploit |= populateExploitAvailability(item, availabilities, "faultmanager", "4 - 9");
     hasExploit |= populateExploitAvailability(item, availabilities, "mvpd", "<3.5");
+    hasExploit |= populateExploitAvailability(item, availabilities, "dangbro", "7 - 10");
   }
   return hasExploit;
 }

--- a/website/src/app.ts
+++ b/website/src/app.ts
@@ -65,6 +65,7 @@ export declare interface ExploitMethod {
     key: DeviceExploitType;
     url: string;
     expert?: boolean;
+    dvbOnly?: boolean;
 }
 
 class App extends Component<AppProps, AppState> {
@@ -104,6 +105,12 @@ class App extends Component<AppProps, AppState> {
             name: 'RootMy.TV',
             key: DeviceExploitType.RootMyTV,
             url: 'https://rootmy.tv/'
+        },
+        {
+            name: 'DangBro',
+            key: DeviceExploitType.DangBro,
+            url: 'https://azoffshowy.github.io/dangbro/',
+            dvbOnly: true
         },
     ];
 

--- a/website/src/app.ts
+++ b/website/src/app.ts
@@ -72,6 +72,12 @@ class App extends Component<AppProps, AppState> {
 
     readonly exploits: ExploitMethod[] = [
         {
+            name: 'DangBro',
+            key: DeviceExploitType.DangBro,
+            url: 'https://azoffshowy.github.io/dangbro/',
+            dvbOnly: true
+        },
+        {
             name: 'faultmanager',
             key: DeviceExploitType.FaultManager,
             url: 'https://github.com/throwaway96/faultmanager-autoroot'
@@ -105,12 +111,6 @@ class App extends Component<AppProps, AppState> {
             name: 'RootMy.TV',
             key: DeviceExploitType.RootMyTV,
             url: 'https://rootmy.tv/'
-        },
-        {
-            name: 'DangBro',
-            key: DeviceExploitType.DangBro,
-            url: 'https://azoffshowy.github.io/dangbro/',
-            dvbOnly: true
         },
     ];
 

--- a/website/src/exploit.ts
+++ b/website/src/exploit.ts
@@ -28,6 +28,11 @@ export function ExploitCard(props: { exploit: ExploitMethod, avail: ExploitAvail
             ${firmware && html` (you have <b>${firmware}</b>)`}
           </div>
         `}
+        ${exploit.dvbOnly && html`
+          <div>
+            <i class="bi bi-broadcast me-2"/>Only works on devices with a DVB broadcast tuner.
+          </div>
+        `}
         ${exploit.expert && html`
           <div>
             <i class="bi bi-exclamation-triangle-fill me-2"/>Requires expert knowledge.


### PR DESCRIPTION
## Summary
- Adds the **DangBro** exploit type (dangbei-overlay based) to the exploit enum.
- Surfaces it on the website as an exploit card, with a note that it **only works on devices with a DVB broadcast tuner**.

## Changes
- `src/library.js` / `src/library.d.ts` — new `DeviceExploitType.DangBro` enum member (value `'dangbro'`) and `dangbro?` availability field.
- `website/src/app.ts` — registers the DangBro exploit (`url: https://azoffshowy.github.io/dangbro/`, `dvbOnly: true`) and adds the `dvbOnly` flag to `ExploitMethod`.
- `website/src/exploit.ts` — `ExploitCard` renders an "Only works on devices with a DVB broadcast tuner" note (📡 `bi-broadcast`) when `dvbOnly` is set.

## Notes
- The DangBro card only renders for a device once `availability.dangbro` exists. That **availability data is populated separately** — via `gen-exploits.js` reading the new `dangbro` field exported by `snu-db` (webosbrew/webos-fw-db#2).
- Website builds clean (`npm run build --prefix website`); only the pre-existing bundle-size warnings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)