### PR TITLE
Fix JSDoc annotations

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -16,7 +16,7 @@ export const DeviceExploitType = {
 
 export class DeviceExploitAvailabilities {
   /**
-   * @param props {Readonly<DeviceExploitAvailabilitiesData & {otaId:string}>}
+   * @param {Readonly<DeviceExploitAvailabilitiesData & {otaId:string}>} props
    */
   constructor(props) {
     Object.assign(this, props);
@@ -61,7 +61,7 @@ export class DeviceExploitAvailabilities {
   }
 
   /**
-   * @param otaId {string}
+   * @param {string} otaId
    * @return {string[]}
    */
   static codenamesByOTAID(otaId) {
@@ -71,7 +71,7 @@ export class DeviceExploitAvailabilities {
 
 export class DeviceModelName {
   /**
-   * @param props {Readonly<DeviceModelNameData>}
+   * @param {Readonly<DeviceModelNameData>} props
    */
   constructor(props) {
     Object.assign(this, props);
@@ -124,7 +124,7 @@ export class DeviceModelName {
   }
 
   /**
-   * @param match {string}
+   * @param {string} match
    * @return {boolean}
    * @package
    */
@@ -150,14 +150,14 @@ export class DeviceModelName {
 
 export class DeviceModel {
   /**
-   * @param props {DeviceModelData & {model: string}}
+   * @param {DeviceModelData & {model: string}} props
    */
   constructor(props) {
     Object.assign(this, props);
   }
 
   /**
-   * @param predicate {(variant: Readonly<DeviceModelVariantData>) => boolean}
+   * @param {(variant: Readonly<DeviceModelVariantData>) => boolean} predicate
    * @returns {DeviceModel|undefined}
    */
   variant(predicate) {
@@ -248,8 +248,8 @@ export class DeviceModel {
 
   /**
    * Get length of different suffixes between two strings
-   * @param k {string}
-   * @param f {string}
+   * @param {string} k
+   * @param {string} f
    * @return {number}
    * @private
    */

--- a/tools/device-model.js
+++ b/tools/device-model.js
@@ -1,10 +1,10 @@
 import {machineOtaIdPrefix, minorMajor, regionBroadcasts} from "./mappings.js";
 
 /**
- * @param broadcast {string}
- * @param otaIdPrefix {string}
- * @param region {string}
- * @return {string|undefined}
+ * @param {string} broadcast
+ * @param {string} otaIdPrefix
+ * @param {string} region
+ * @returns {string | undefined}
  */
 function inferBroadcast(broadcast, otaIdPrefix, region) {
   if (broadcast !== 'global') {
@@ -20,9 +20,9 @@ function inferBroadcast(broadcast, otaIdPrefix, region) {
 }
 
 /**
- * @param prefix {string}
- * @param broadcast {string}
- * @return {string | undefined}
+ * @param {string} prefix
+ * @param {string} broadcast
+ * @returns {string | undefined}
  */
 function inferOtaIdBroadcastSuffix(prefix, broadcast) {
   switch (broadcast) {
@@ -46,9 +46,9 @@ function inferOtaIdBroadcastSuffix(prefix, broadcast) {
 }
 
 /**
- * @param machine {string}
- * @param predicate {({codename?: string, broascast?: string, otaId: string}) => boolean}
- * @returns {string|undefined}
+ * @param {string} machine
+ * @param {(ota: {codename?: string, broadcast?: string, otaId: string}) => boolean} predicate
+ * @returns {string | undefined}
  */
 function findOtaIdPrefix(machine, predicate) {
   let otaIds = machineOtaIdPrefix[machine];
@@ -73,10 +73,10 @@ export const epkNameRegex = new RegExp([
 ].map(r => r.source).join(''));
 
 /**
- * @param model {DeviceModelName}
- * @param epk {string}
- * @param region {string}
- * @param [otaId] {string}
+ * @param {DeviceModelName} model
+ * @param {string} epk
+ * @param {string} region
+ * @param {string} [otaId]
  * @returns {Omit<DeviceModelData, 'sizes'|'regions'|'variants'> | undefined}
  */
 export function parseDeviceModel(model, epk, region, otaId) {

--- a/tools/gen-exploits.js
+++ b/tools/gen-exploits.js
@@ -40,10 +40,10 @@ let output = {};
 
 /**
  *
- * @param item {DumpItem} Dump item to populate
- * @param availabilities {DeviceExploitAvailabilitiesData} Firmware item to populate
- * @param key {string} Name of the exploit
- * @param webosSatisfies {string} webOS version that satisfies the exploit
+ * @param {DumpItem} item Dump item to populate
+ * @param {DeviceExploitAvailabilitiesData} availabilities Firmware item to populate
+ * @param {string} key Name of the exploit
+ * @param {string} webosSatisfies webOS version that satisfies the exploit
  * @return {boolean}
  */
 function populateExploitAvailability(item, availabilities, key, webosSatisfies) {
@@ -80,13 +80,13 @@ function populateExploitAvailability(item, availabilities, key, webosSatisfies) 
 
 /**
  * Compare two OTA IDs by their generation
- * @param a {string}
- * @param b {string}
+ * @param {string} a
+ * @param {string} b
  * @returns {number}
  */
 function compareOTAID(a, b) {
   /**
-   * @param otaId {string}
+   * @param {string} otaId
    * @return {{typ: string, cls: string, gen: number, ser: string, reg: string}}
    */
   function parseOTAID(otaId) {
@@ -119,8 +119,8 @@ function compareOTAID(a, b) {
 
 /**
  *
- * @param availabilities {DeviceExploitAvailabilitiesData}
- * @param items {DumpItem[]}
+ * @param {DeviceExploitAvailabilitiesData} availabilities
+ * @param {DumpItem[]} items
  * @returns {boolean}
  */
 function populateAvailabilities(availabilities, items) {

--- a/tools/gen-models.js
+++ b/tools/gen-models.js
@@ -55,7 +55,7 @@ const updatesGrouped = groupBy(updates, item => {
 });
 
 /**
- * @param epk {string}
+ * @param {string} epk
  * @return {string | undefined}
  */
 function epkBroadcast(epk) {
@@ -63,7 +63,7 @@ function epkBroadcast(epk) {
 }
 
 /**
- * @param item {GroupedModelItem}
+ * @param {GroupedModelItem} item
  * @return {boolean}
  */
 function isMismatch(item) {
@@ -73,11 +73,11 @@ function isMismatch(item) {
 }
 
 /**
- * @param model {DeviceModelName}
- * @param epk {string}
- * @param otaId {string}
- * @param items {GroupedModelItem[]}
- * @param getter {(item: GroupedModelItem) => any}
+ * @param {DeviceModelName} model
+ * @param {string} epk
+ * @param {string} otaId
+ * @param {GroupedModelItem[]} items
+ * @param {(item: GroupedModelItem) => any} getter
  */
 function modelsProps(model, epk, otaId, items, getter) {
   /**
@@ -92,9 +92,9 @@ function modelsProps(model, epk, otaId, items, getter) {
     return v.model.simple === model.simple;
   }
 
-  return chain(items).groupBy(/** @param x {GroupedModelItem} */(x) => getter(x))
+  return chain(items).groupBy(/** @param {GroupedModelItem} x */(x) => getter(x))
     .values()
-    .map(/** @param g {GroupedModelItem[]} */(g) => {
+    .map(/** @param {GroupedModelItem[]} g */(g) => {
       const filtered = g.filter(v => v.ota_id);
       if (filtered.length > 1) {
         return filtered;
@@ -102,7 +102,7 @@ function modelsProps(model, epk, otaId, items, getter) {
       return g;
     })
     .flatten()
-    .map(/** @param x {GroupedModelItem} */(x) => sameVariation(x) && getter(x))
+    .map(/** @param {GroupedModelItem} x */(x) => sameVariation(x) && getter(x))
     .compact()
     .uniq()
     .sort()

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = (env, argv) => ({
       /** @returns {string[]} */
       paths: () => {
         const entries = fs.readdirSync(path.resolve(__dirname, 'src'), {recursive: true, encoding: 'utf-8'});
-        return entries.map(/**@param name{string}*/(name) => path.join('src', name));
+        return entries.map(/** @param {string} name */(name) => path.join('src', name));
       },
     }),
   ],


### PR DESCRIPTION
## What

Fix JSDoc annotations across `src`, `website` and `tools` by updating parameter and return type syntax to the standard JSDoc format.

JSDoc docs; 

https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html