### PR TITLE
Update Exploits Info

### DIFF
--- a/src/exploits.gen.js
+++ b/src/exploits.gen.js
@@ -2163,6 +2163,158 @@ export default {
       }
     }
   },
+  "HE_DTV_C20L_AFAAABAA": {
+    "jhericurl": {
+      "rootmytv": {
+        "latest": {
+          "version": "04.30.40",
+          "release": "5.3.0-19",
+          "codename": "jhericurl-jasper"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
+        }
+      },
+      "crashd": {
+        "latest": {
+          "version": "04.30.40",
+          "release": "5.3.0-19",
+          "codename": "jhericurl-jasper"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
+        }
+      },
+      "wta": {
+        "latest": {
+          "version": "04.30.40",
+          "release": "5.3.0-19",
+          "codename": "jhericurl-jasper"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
+        }
+      },
+      "asm": {
+        "latest": {
+          "version": "04.30.40",
+          "release": "5.3.0-19",
+          "codename": "jhericurl-jasper"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
+        }
+      },
+      "dejavuln": {
+        "latest": {
+          "version": "04.30.40",
+          "release": "5.3.0-19",
+          "codename": "jhericurl-jasper"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
+        }
+      },
+      "faultmanager": {
+        "latest": {
+          "version": "04.30.40",
+          "release": "5.3.0-19",
+          "codename": "jhericurl-jasper"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
+        }
+      }
+    }
+  },
+  "HE_DTV_C20L_AFAAATAA": {
+    "jhericurl": {
+      "rootmytv": {
+        "latest": {
+          "version": "04.30.40",
+          "release": "5.3.0-19",
+          "codename": "jhericurl-jasper"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
+        }
+      },
+      "crashd": {
+        "latest": {
+          "version": "04.30.40",
+          "release": "5.3.0-19",
+          "codename": "jhericurl-jasper"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
+        }
+      },
+      "wta": {
+        "latest": {
+          "version": "04.30.40",
+          "release": "5.3.0-19",
+          "codename": "jhericurl-jasper"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
+        }
+      },
+      "asm": {
+        "latest": {
+          "version": "04.30.40",
+          "release": "5.3.0-19",
+          "codename": "jhericurl-jasper"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
+        }
+      },
+      "dejavuln": {
+        "latest": {
+          "version": "04.30.40",
+          "release": "5.3.0-19",
+          "codename": "jhericurl-jasper"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
+        }
+      },
+      "faultmanager": {
+        "latest": {
+          "version": "04.30.40",
+          "release": "5.3.0-19",
+          "codename": "jhericurl-jasper"
+        },
+        "patched": {
+          "version": "04.60.95",
+          "release": "5.6.0-20",
+          "codename": "jhericurl-jimna"
+        }
+      }
+    }
+  },
   "HE_DTV_C20P_AFADABAA": {
     "jhericurl": {
       "rootmytv": {
@@ -4298,6 +4450,11 @@ export default {
   "HE_DTV_W22H_AFADATAA": {
     "mullet": {
       "rootmytv": {
+        "latest": {
+          "version": "02.00.81",
+          "release": "7.1.0-81",
+          "codename": "mullet-maria"
+        },
         "patched": {
           "version": "03.10.70",
           "release": "7.1.0-50",
@@ -4445,8 +4602,8 @@ export default {
     "ponytail": {
       "dangbro": {
         "latest": {
-          "version": "33.31.23",
-          "release": "10.3.0-2503",
+          "version": "33.31.61",
+          "release": "10.3.1-3001",
           "codename": "ponytail-papikonda"
         }
       }


### PR DESCRIPTION
Update exploits for @webosbrew/caniroot

- added: exploit information for HE_DTV_C20L_AFAAABAA
- added: exploit information for HE_DTV_C20L_AFAAATAA
- updated: dangbro on HE_DTV_W22H_AFADATAA is known rootable in 33.31.61